### PR TITLE
Potential fix for code scanning alert no. 65: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "req-flash": "0.0.3",
     "sequelize": "^6.37.5",
     "util": "^0.12.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "dompurify": "^3.2.5"
   },
   "repository": {},
   "devDependencies": {

--- a/public/assets/plugins/summernote/summernote-bs4.js
+++ b/public/assets/plugins/summernote/summernote-bs4.js
@@ -9,11 +9,11 @@
  */
 (function (global, factory) {
   typeof exports === "object" && typeof module !== "undefined"
-    ? factory(require("jquery"))
+    ? factory(require("jquery"), require("dompurify"))
     : typeof define === "function" && define.amd
-      ? define(["jquery"], factory)
-      : factory(global.jQuery);
-})(this, function ($$1) {
+      ? define(["jquery", "dompurify"], factory)
+      : factory(global.jQuery, global.DOMPurify);
+})(this, function ($$1, DOMPurify) {
   "use strict";
 
   $$1 = $$1 && $$1.hasOwnProperty("default") ? $$1["default"] : $$1;
@@ -5146,9 +5146,9 @@
             $$1.each(dataTransfer.types, function (idx, type) {
               var content = dataTransfer.getData(type);
               if (type.toLowerCase().indexOf("text") > -1) {
-                _this.context.invoke("editor.pasteHTML", content);
+                _this.context.invoke("editor.pasteHTML", DOMPurify.sanitize(content));
               } else {
-                $$1(content).each(function (idx, item) {
+                $$1(DOMPurify.sanitize(content)).each(function (idx, item) {
                   _this.context.invoke("editor.insertNode", item);
                 });
               }


### PR DESCRIPTION
Potential fix for [https://github.com/AdrianNadeau/priority-pilot/security/code-scanning/65](https://github.com/AdrianNadeau/priority-pilot/security/code-scanning/65)

To fix the problem, we need to ensure that the user-provided data is properly sanitized before being inserted into the DOM. One effective way to do this is by using a library like DOMPurify, which can sanitize HTML and prevent XSS attacks.

- In general terms, the problem can be fixed by sanitizing the `content` variable before it is used in the `$$1(content).each` function.
- Specifically, we will import the DOMPurify library and use it to sanitize the `content` variable before it is inserted into the DOM.
- The changes will be made in the `public/assets/plugins/summernote/summernote-bs4.js` file, around lines 5147-5151.
- We will need to add an import statement for DOMPurify and use it to sanitize the `content` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
